### PR TITLE
fix(openviking): loosen probes for slow embedder calls

### DIFF
--- a/argocd/apps/erin-apps/openviking/base/deployment.yaml
+++ b/argocd/apps/erin-apps/openviking/base/deployment.yaml
@@ -53,16 +53,23 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            # /health can stall behind a slow (~10s) embedder call on the
+            # single worker; keep liveness lenient so transient slowness
+            # never triggers a restart loop.
+            timeoutSeconds: 10
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /ready
               port: http
             initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 15
+            # OpenRouter embedding calls (qwen3-embedding-8b) routinely take
+            # ~10s; with workers:1 that pushes /ready past a tight deadline
+            # and flaps the pod out of the Service. Tolerate it: 10s timeout
+            # and 6 failures (~90s) before marking NotReady.
+            timeoutSeconds: 10
+            failureThreshold: 6
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
## What

Widen the openviking Deployment's liveness/readiness probes so transient embedder slowness no longer flaps the pod.

- **readiness** (`/ready`): `timeoutSeconds` 5→10, `failureThreshold` 3→6, `periodSeconds` 10→15
- **liveness** (`/health`): `timeoutSeconds` 5→10, `failureThreshold` 3→5

## Why

The OpenRouter embedding model `qwen3-embedding-8b` routinely takes **~10s** per call. With `workers: 1`, that pushes `/ready` past the old 5s deadline; after 3 failures the pod drops out of the Service and the Tailscale ingress returns **502**. Observed live: the pod flapped `0/1` with `Readiness probe failed: ... context deadline exceeded` while the app was otherwise healthy (embedder calls are slow, not erroring — no tracebacks).

New tolerance: ~90s (readiness) / ~150s (liveness) of slowness before the pod is marked down.

## Follow-ups (not in this PR)
- Consider `workers > 1` or a faster/more local embedding backend to remove the root-cause latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)